### PR TITLE
Syllabus for Particular Year Displayed

### DIFF
--- a/src/components/page3/1Year.js
+++ b/src/components/page3/1Year.js
@@ -36,7 +36,7 @@ function fstYear() {
 </div>
 </Link>
 
-<Link class="link" to='/syllabus'>
+<Link class="link" to='/fstsyllabus'>
 <div class="card pink">
 <img src={syllabus} alt="" />
   <p class="second-text">Syllabus</p>

--- a/src/components/page3/2Year.js
+++ b/src/components/page3/2Year.js
@@ -35,7 +35,7 @@ function sndYear() {
   </div>
   </Link>
 
- <Link class="link" to='/syllabus'>
+ <Link class="link" to='/sndsyllabus'>
   <div class="card pink">
   <img src={syllabus} alt="" />
     <p class="second-text">Syllabus</p>

--- a/src/components/page3/3Year.js
+++ b/src/components/page3/3Year.js
@@ -38,7 +38,7 @@ function TrdYear() {
     </div>
     </Link>
 
-   <Link class="link" to='/syllabus'>
+   <Link class="link" to='/trdsyllabus'>
     <div class="card pink">
     <img src={syllabus} alt="" />
       <p class="second-text">Syllabus</p>

--- a/src/components/page3/4Year.js
+++ b/src/components/page3/4Year.js
@@ -1,20 +1,7 @@
-// import React from 'react'
-
-// function fothYear() {
-//   return (
-//     <div>
-//       <h1>Fourth Year</h1>
-//     </div>
-//   )
-// }
-
-// export default fothYear
-
-
 import React from 'react'
 import {Link} from 'react-router-dom';
-// import '../page3/3Year.css'
 import Header from '../../pages/header';
+import '../page3/1Year.css';
 
 
 import quantumImage from '../../assets/5th.png';
@@ -27,13 +14,44 @@ import ComingSoon from '../../pages/cs.js'
 
 function fothYear() {
 
-  return (
-    <div>
-    <ComingSoon />
+ 
+    return (
+  <div>
 
-{/* <Footer /> */}
+  <Header/>
+    
+    <div className="yr">
+    <h2>4th year</h2>
     </div>
-  )
-}
+
+    <div className="content">
+      <div className="cards">
+  
+
+
+  <Link to='/frthsyllabus'>
+  <div className="card pink">
+  <img src={syllabus} alt="" />
+    <p className="second-text">Syllabus</p>
+  </div> 
+  </Link>
+
+  
+
+  
+
+  
+
+  </div>
+  </div>
+
+  </div>
+
+    )
+  }
+
+
+
+
 
 export default fothYear;

--- a/src/components/page6(2nd)/sndsyllabus.js
+++ b/src/components/page6(2nd)/sndsyllabus.js
@@ -4,7 +4,7 @@ import Footer from "../../pages/footer";
 import '../page4/syllabus.css';
 
 
-const fstsyllabus =() => {
+const Syllabus =() => {
 
     // const[selectSem, setSelectSem] = useState(null);
 
@@ -21,22 +21,27 @@ const fstsyllabus =() => {
   return (
     <div>
         <Header/>
+
+
          <h2 className='head'> Download Syllabus</h2>
          
          <div class="ag-format-container">
   <div class="ag-courses_box">
+    
+
+    
+
     <div class="ag-courses_item">
       <a href="#" class="ag-courses-item_link">
         <div class="ag-courses-item_bg"></div>
 
         <div class="ag-courses-item_title">
-         Semester 1st
+       Semester 3rd
         </div>
 
         <div class="ag-courses-item_date-box">
-         
           <span class="ag-courses-item_date">
-          <button onClick={() => handleDownload("1stsem")} >Download</button>
+          <button onClick={() => handleDownload("3rdsem")} >Download</button>
 
           </span>
         </div>
@@ -48,17 +53,21 @@ const fstsyllabus =() => {
         <div class="ag-courses-item_bg"></div>
 
         <div class="ag-courses-item_title">
-            Semester 2nd
-         </div>
+          Semester 4th
+        </div>
 
         <div class="ag-courses-item_date-box">
-        
+          
           <span class="ag-courses-item_date">
-          <button onClick={() => handleDownload("2ndsem")} >Download</button>
+          <button onClick={() => handleDownload("4thsem")} >Download</button>
           </span>
         </div>
       </a>
     </div>
+
+
+    
+
   </div>
 </div>
       <Footer/>
@@ -66,8 +75,6 @@ const fstsyllabus =() => {
   )
 }
 
-export default fstsyllabus
-
-
+export default Syllabus
 
 

--- a/src/components/page7(4yr)/frthsyllabus.js
+++ b/src/components/page7(4yr)/frthsyllabus.js
@@ -4,7 +4,7 @@ import Footer from "../../pages/footer";
 import '../page4/syllabus.css';
 
 
-const fstsyllabus =() => {
+const frthsyllabus =() => {
 
     // const[selectSem, setSelectSem] = useState(null);
 
@@ -21,22 +21,26 @@ const fstsyllabus =() => {
   return (
     <div>
         <Header/>
+
+
          <h2 className='head'> Download Syllabus</h2>
          
          <div class="ag-format-container">
   <div class="ag-courses_box">
+    
+
     <div class="ag-courses_item">
       <a href="#" class="ag-courses-item_link">
         <div class="ag-courses-item_bg"></div>
 
         <div class="ag-courses-item_title">
-         Semester 1st
+         Semester 7th
         </div>
 
         <div class="ag-courses-item_date-box">
-         
+          
           <span class="ag-courses-item_date">
-          <button onClick={() => handleDownload("1stsem")} >Download</button>
+          <button onClick={() => handleDownload("4thyrsyllabus")} >Download</button>
 
           </span>
         </div>
@@ -48,17 +52,23 @@ const fstsyllabus =() => {
         <div class="ag-courses-item_bg"></div>
 
         <div class="ag-courses-item_title">
-            Semester 2nd
-         </div>
+         Semester 8th
+        </div>
 
         <div class="ag-courses-item_date-box">
-        
+          
           <span class="ag-courses-item_date">
-          <button onClick={() => handleDownload("2ndsem")} >Download</button>
+          <button onClick={() => handleDownload("4thyrsyllabus")} >Download</button>
+
           </span>
         </div>
       </a>
-    </div>
+    </div> 
+    
+   
+
+    
+
   </div>
 </div>
       <Footer/>
@@ -66,8 +76,6 @@ const fstsyllabus =() => {
   )
 }
 
-export default fstsyllabus
-
-
+export default frthsyllabus
 
 

--- a/src/components/page8(3yr)/trdsyllabus.js
+++ b/src/components/page8(3yr)/trdsyllabus.js
@@ -4,7 +4,7 @@ import Footer from "../../pages/footer";
 import '../page4/syllabus.css';
 
 
-const fstsyllabus =() => {
+const trdsyllabus =() => {
 
     // const[selectSem, setSelectSem] = useState(null);
 
@@ -21,22 +21,31 @@ const fstsyllabus =() => {
   return (
     <div>
         <Header/>
+
+
          <h2 className='head'> Download Syllabus</h2>
          
          <div class="ag-format-container">
   <div class="ag-courses_box">
+    
+
+    
+
+   
+
+    
     <div class="ag-courses_item">
       <a href="#" class="ag-courses-item_link">
         <div class="ag-courses-item_bg"></div>
 
         <div class="ag-courses-item_title">
-         Semester 1st
+         Semester 5th
         </div>
 
         <div class="ag-courses-item_date-box">
-         
+          
           <span class="ag-courses-item_date">
-          <button onClick={() => handleDownload("1stsem")} >Download</button>
+          <button onClick={() => handleDownload("5thsem")} >Download</button>
 
           </span>
         </div>
@@ -48,13 +57,14 @@ const fstsyllabus =() => {
         <div class="ag-courses-item_bg"></div>
 
         <div class="ag-courses-item_title">
-            Semester 2nd
-         </div>
+         Semester 6th
+        </div>
 
         <div class="ag-courses-item_date-box">
-        
+          
           <span class="ag-courses-item_date">
-          <button onClick={() => handleDownload("2ndsem")} >Download</button>
+          <button onClick={() => handleDownload("6thsem")} >Download</button>
+
           </span>
         </div>
       </a>
@@ -66,8 +76,6 @@ const fstsyllabus =() => {
   )
 }
 
-export default fstsyllabus
-
-
+export default trdsyllabus
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,10 @@ import SndQuantum from './components/page6(2nd)/sndquantum.js'
 import SndLecture from './components/page6(2nd)/sndlecture.js'
 import Fsttimetable from './components/page5(1st)/fsttimetable.js'
 import Sndtimetable from './components/page6(2nd)/sndtimetable.js';
-
+import Fstsyllabus from './components/page5(1st)/fstsyllabus.js';
+import Sndsyllabus from './components/page6(2nd)/sndsyllabus.js'
+import Frthsyllabus from './components/page7(4yr)/frthsyllabus.js'
+import TrdSyllabus from './components/page8(3yr)/trdsyllabus.js';
 import {
   createBrowserRouter,
   RouterProvider,
@@ -45,9 +48,25 @@ const router = createBrowserRouter([
     path: "/",
     element: <App />,
   },
+  //  {
+  //   path: "syllabus",
+  //   element: <Syllabus/>
+  //  },
    {
-    path: "syllabus",
-    element: <Syllabus/>
+    path:"fstsyllabus",
+    element:<Fstsyllabus/>
+   },
+   {
+    path:"sndsyllabus",
+    element:<Sndsyllabus/>
+   },
+   {
+    path:"trdsyllabus",
+    element:<TrdSyllabus/>
+   },
+   {
+    path:"frthsyllabus",
+    element:<Frthsyllabus/>
    },
    {
     path: "timetable",


### PR DESCRIPTION
Issue No:#5 

### Closes Issue #5

**Description**:
When the year is clicked followed by the Syllabus..it displays the syllabus for 8 semesters but it has to be displayed for the selected year's semester(i.e. if the 2nd year is selected, the 3rd and 4th sem has to be displayed). The issue has been resolved by providing correct routing and creating separate folders. Now the output will be when a particular year is selected then the particular semesters will be displayed for syllabus download.

My code follows the guidelines and does not produce any warnings.

**Test**:
 I have tested with all four years and attached the video document below.
 
 I am a GSSoC'24 Contributor.

Screenshots/Video

https://github.com/AbhiDiva96/75per/assets/123291594/a7cfef4b-764c-4a2b-b7ec-089f1b4a2bf1


