### PR TITLE
feat: Adding View button to syllabus components for all years

### DIFF
--- a/src/components/page4/syllabus.css
+++ b/src/components/page4/syllabus.css
@@ -1,167 +1,174 @@
 .ag-format-container {
-    width: 1142px;
-    height: 60vh;
-    margin: 0 auto;
-  }
-  
-  
-  /* body {
-    background-color: #000;
-  } */
-  .ag-courses_box {
-    display: -webkit-box;
-    display: -ms-flexbox;
-    display: flex;
-    -webkit-box-align: start;
-    -ms-flex-align: start;
-    align-items: flex-start;
-    -ms-flex-wrap: wrap;
-    flex-wrap: wrap;
-  
-    padding: 50px 0;
-  }
+  width: 1142px;
+  height: 60vh;
+  margin: 0 auto;
+}
+
+.ag-courses_box {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: flex-start;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+
+  padding: 50px 0;
+}
+
+.ag-courses_item {
+  -ms-flex-preferred-size: calc(33.33333% - 30px);
+  flex-basis: calc(33.33333% - 30px);
+
+  margin: 0 15px 30px;
+
+  overflow: hidden;
+
+  border-radius: 28px;
+}
+
+.ag-courses-item_link {
+  display: block;
+  padding: 30px 20px;
+  background-color: #121212;
+
+  overflow: hidden;
+
+  position: sticky;
+}
+
+.ag-courses-item_link:hover,
+.ag-courses-item_link:hover .ag-courses-item_date {
+  text-decoration: none;
+  color: #FFF;
+}
+
+.ag-courses-item_link:hover .ag-courses-item_bg {
+  -webkit-transform: scale(10);
+  -ms-transform: scale(10);
+  transform: scale(10);
+}
+
+.active .ag-courses-item_link {
+  background-color: black;
+}
+
+.ag-courses-item_title {
+  min-height: 87px;
+  margin: 0 0 25px;
+  background-color: transparent !important;
+  overflow: hidden;
+
+  font-weight: bold;
+  font-size: 30px;
+  color: #FFF;
+
+  z-index: 2;
+  position: relative;
+}
+
+.ag-courses-item_date-box {
+  font-size: 18px;
+  color: #FFF;
+
+  z-index: 2;
+  position: relative;
+}
+
+.ag-courses-item_date {
+  font-weight: bold;
+  color: #f9b234;
+
+  -webkit-transition: color .5s ease;
+  -o-transition: color .5s ease;
+  transition: color .5s ease;
+}
+
+.ag-courses-item_bg {
+  height: 128px;
+  width: 128px;
+  background-color: #f9b234;
+
+  z-index: 1;
+  position: absolute;
+  top: -75px;
+  right: -75px;
+
+  border-radius: 50%;
+
+  -webkit-transition: all .5s ease;
+  -o-transition: all .5s ease;
+  transition: all .5s ease;
+}
+
+.ag-courses_item:nth-child(2n) .ag-courses-item_bg {
+  background-color: #3ecd5e;
+}
+
+.ag-courses_item:nth-child(3n) .ag-courses-item_bg {
+  background-color: #e44002;
+}
+
+.ag-courses_item:nth-child(4n) .ag-courses-item_bg {
+  background-color: #952aff;
+}
+
+.ag-courses_item:nth-child(5n) .ag-courses-item_bg {
+  background-color: #cd3e94;
+}
+
+.ag-courses_item:nth-child(6n) .ag-courses-item_bg {
+  background-color: #4c49ea;
+}
+
+.ag-courses-item_date button {
+  padding: 8px;
+  border-radius: 5px;
+  border: 2px solid #4654cb;
+  background-color: #5931de;
+  color: #f4f4f4;
+  font-weight: 200;
+  margin: 0 5px; /* Add margin between buttons */
+}
+
+.ag-courses-item_date button:hover {
+  background-color: white;
+  color: black;
+  border: 2px solid white;
+}
+
+@media only screen and (max-width: 979px) {
   .ag-courses_item {
-    -ms-flex-preferred-size: calc(33.33333% - 30px);
-    flex-basis: calc(33.33333% - 30px);
-  
-    margin: 0 15px 30px;
-  
-    overflow: hidden;
-  
-    border-radius: 28px;
-  }
-  
-  .ag-courses-item_link {
-    display: block;
-    padding: 30px 20px;
-    background-color: #121212;
-  
-    overflow: hidden;
-  
-    position: sticky;
-  }
-  .ag-courses-item_link:hover,
-  .ag-courses-item_link:hover .ag-courses-item_date {
-    text-decoration: none;
-    color: #FFF;
-  }
-  .ag-courses-item_link:hover .ag-courses-item_bg {
-    -webkit-transform: scale(10);
-    -ms-transform: scale(10);
-    transform: scale(10);
-  }
-  .active .ag-courses-item_link{
-    background-color: black;
+    -ms-flex-preferred-size: calc(50% - 30px);
+    flex-basis: calc(50% - 30px);
   }
   .ag-courses-item_title {
-    min-height: 87px;
-    margin: 0 0 25px;
-    background-color: transparent !important;
-    overflow: hidden;
-  
-    font-weight: bold;
-    font-size: 30px;
-    color: #FFF;
-  
-    z-index: 2;
-    position: relative;
+    font-size: 24px;
+  }
+}
+
+@media only screen and (max-width: 767px) {
+  .ag-format-container {
+    width: 96%;
+  }
+}
+
+@media only screen and (max-width: 639px) {
+  .ag-courses_item {
+    -ms-flex-preferred-size: 100%;
+    flex-basis: 100%;
+  }
+  .ag-courses-item_title {
+    min-height: 72px;
+    line-height: 1;
+
+    font-size: 24px;
+  }
+  .ag-courses-item_link {
+    padding: 22px 40px;
   }
   .ag-courses-item_date-box {
-    font-size: 18px;
-    color: #FFF;
-  
-    z-index: 2;
-    position: relative;
+    font-size: 16px;
   }
-  .ag-courses-item_date {
-    font-weight: bold;
-    color: #f9b234;
-  
-    -webkit-transition: color .5s ease;
-    -o-transition: color .5s ease;
-    transition: color .5s ease
-  }
-  .ag-courses-item_bg {
-    height: 128px;
-    width: 128px;
-    background-color: #f9b234;
-  
-    z-index: 1;
-    position: absolute;
-    top: -75px;
-    right: -75px;
-  
-    border-radius: 50%;
-  
-    -webkit-transition: all .5s ease;
-    -o-transition: all .5s ease;
-    transition: all .5s ease;
-  }
-  .ag-courses_item:nth-child(2n) .ag-courses-item_bg {
-    background-color: #3ecd5e;
-  }
-  .ag-courses_item:nth-child(3n) .ag-courses-item_bg {
-    background-color: #e44002;
-  }
-  .ag-courses_item:nth-child(4n) .ag-courses-item_bg {
-    background-color: #952aff;
-  }
-  .ag-courses_item:nth-child(5n) .ag-courses-item_bg {
-    background-color: #cd3e94;
-  }
-  .ag-courses_item:nth-child(6n) .ag-courses-item_bg {
-    background-color: #4c49ea;
-  }
-
-  .ag-courses-item_date button{
-    padding: 8px;
-    border-radius: 5px;
-    border: 2px solid #4654cb;
-    background-color: #5931de;
-    color: #f4f4f4;
-    font-weight: 200;
-     
-  }
-
-  .ag-courses-item_date button:hover{
-    background-color: white;
-    color: black;
-    border: 2px solid white;
-  }
-  
-  
-  
-  @media only screen and (max-width: 979px) {
-    .ag-courses_item {
-      -ms-flex-preferred-size: calc(50% - 30px);
-      flex-basis: calc(50% - 30px);
-    }
-    .ag-courses-item_title {
-      font-size: 24px;
-    }
-  }
-  
-  @media only screen and (max-width: 767px) {
-    .ag-format-container {
-      width: 96%;
-    }
-  
-  }
-  @media only screen and (max-width: 639px) {
-    .ag-courses_item {
-      -ms-flex-preferred-size: 100%;
-      flex-basis: 100%;
-    }
-    .ag-courses-item_title {
-      min-height: 72px;
-      line-height: 1;
-  
-      font-size: 24px;
-    }
-    .ag-courses-item_link {
-      padding: 22px 40px;
-    }
-    .ag-courses-item_date-box {
-      font-size: 16px;
-    }
-  }
+}

--- a/src/components/page4/syllabus.js
+++ b/src/components/page4/syllabus.js
@@ -4,8 +4,6 @@ import Footer from "../../pages/footer";
 import "../page4/syllabus.css";
 
 const Syllabus = () => {
-  // const[selectSem, setSelectSem] = useState(null);
-
   const handleDownload = (syllabus) => {
     const syllabusFilePath =
       process.env.PUBLIC_URL + `/syllabus/${syllabus}.pdf`;
@@ -17,147 +15,137 @@ const Syllabus = () => {
     link.click();
     document.body.removeChild(link);
   };
+
+  const handleView = (syllabus) => {
+    const syllabusFilePath =
+      process.env.PUBLIC_URL + `/syllabus/${syllabus}.pdf`;
+
+    window.open(syllabusFilePath, "_blank");
+  };
+
   return (
     <div>
       <Header />
 
-      <h2 className="head"> Download Syllabus</h2>
+      <h2 className="head">Download Syllabus</h2>
 
-      <div class="ag-format-container">
-        <div class="ag-courses_box">
-          <div class="ag-courses_item">
-            <a href="#" class="ag-courses-item_link">
-              <div class="ag-courses-item_bg"></div>
+      <div className="ag-format-container">
+        <div className="ag-courses_box">
+          <div className="ag-courses_item">
+            <a href="#" className="ag-courses-item_link">
+              <div className="ag-courses-item_bg"></div>
 
-              <div
-                class="ag-courses-item_title"
-                
-              >
-                Semester 1st
-              </div>
+              <div className="ag-courses-item_title">Semester 1st</div>
 
-              <div class="ag-courses-item_date-box">
-                <span class="ag-courses-item_date">
-                  <button onClick={() => handleDownload("1stsem")}>
-                    Download
-                  </button>
+              <div className="ag-courses-item_date-box">
+                <span className="ag-courses-item_date">
+                  <button onClick={() => handleDownload("1stsem")}>Download</button>
+                  <button onClick={() => handleView("1stsem")}>View</button>
                 </span>
               </div>
             </a>
           </div>
 
-          <div class="ag-courses_item">
-            <a href="#" class="ag-courses-item_link">
-              <div class="ag-courses-item_bg"></div>
+          <div className="ag-courses_item">
+            <a href="#" className="ag-courses-item_link">
+              <div className="ag-courses-item_bg"></div>
 
-              <div
-                class="ag-courses-item_title"
-                
-              >
-                Semester 2nd
-              </div>
+              <div className="ag-courses-item_title">Semester 2nd</div>
 
-              <div class="ag-courses-item_date-box">
-                <span class="ag-courses-item_date">
-                  <button onClick={() => handleDownload("2ndsem")}>
-                    Download
-                  </button>
+              <div className="ag-courses-item_date-box">
+                <span className="ag-courses-item_date">
+                  <button onClick={() => handleDownload("2ndsem")}>Download</button>
+                  <button onClick={() => handleView("2ndsem")}>View</button>
                 </span>
               </div>
             </a>
           </div>
 
-          <div class="ag-courses_item">
-            <a href="#" class="ag-courses-item_link">
-              <div class="ag-courses-item_bg"></div>
+          <div className="ag-courses_item">
+            <a href="#" className="ag-courses-item_link">
+              <div className="ag-courses-item_bg"></div>
 
-              <div class="ag-courses-item_title">Semester 3rd</div>
+              <div className="ag-courses-item_title">Semester 3rd</div>
 
-              <div class="ag-courses-item_date-box">
-                <span class="ag-courses-item_date">
-                  <button onClick={() => handleDownload("3rdsem")}>
-                    Download
-                  </button>
+              <div className="ag-courses-item_date-box">
+                <span className="ag-courses-item_date">
+                  <button onClick={() => handleDownload("3rdsem")}>Download</button>
+                  <button onClick={() => handleView("3rdsem")}>View</button>
                 </span>
               </div>
             </a>
           </div>
 
-          <div class="ag-courses_item">
-            <a href="#" class="ag-courses-item_link">
-              <div class="ag-courses-item_bg"></div>
+          <div className="ag-courses_item">
+            <a href="#" className="ag-courses-item_link">
+              <div className="ag-courses-item_bg"></div>
 
-              <div class="ag-courses-item_title">Semester 4th</div>
+              <div className="ag-courses-item_title">Semester 4th</div>
 
-              <div class="ag-courses-item_date-box">
-                <span class="ag-courses-item_date">
-                  <button onClick={() => handleDownload("4thsem")}>
-                    Download
-                  </button>
+              <div className="ag-courses-item_date-box">
+                <span className="ag-courses-item_date">
+                  <button onClick={() => handleDownload("4thsem")}>Download</button>
+                  <button onClick={() => handleView("4thsem")}>View</button>
                 </span>
               </div>
             </a>
           </div>
 
-          <div class="ag-courses_item">
-            <a href="#" class="ag-courses-item_link">
-              <div class="ag-courses-item_bg"></div>
+          <div className="ag-courses_item">
+            <a href="#" className="ag-courses-item_link">
+              <div className="ag-courses-item_bg"></div>
 
-              <div class="ag-courses-item_title">Semester 5th</div>
+              <div className="ag-courses-item_title">Semester 5th</div>
 
-              <div class="ag-courses-item_date-box">
-                <span class="ag-courses-item_date">
-                  <button onClick={() => handleDownload("5thsem")}>
-                    Download
-                  </button>
+              <div className="ag-courses-item_date-box">
+                <span className="ag-courses-item_date">
+                  <button onClick={() => handleDownload("5thsem")}>Download</button>
+                  <button onClick={() => handleView("5thsem")}>View</button>
                 </span>
               </div>
             </a>
           </div>
 
-          <div class="ag-courses_item">
-            <a href="#" class="ag-courses-item_link">
-              <div class="ag-courses-item_bg"></div>
+          <div className="ag-courses_item">
+            <a href="#" className="ag-courses-item_link">
+              <div className="ag-courses-item_bg"></div>
 
-              <div class="ag-courses-item_title">Semester 6th</div>
+              <div className="ag-courses-item_title">Semester 6th</div>
 
-              <div class="ag-courses-item_date-box">
-                <span class="ag-courses-item_date">
-                  <button onClick={() => handleDownload("6thsem")}>
-                    Download
-                  </button>
+              <div className="ag-courses-item_date-box">
+                <span className="ag-courses-item_date">
+                  <button onClick={() => handleDownload("6thsem")}>Download</button>
+                  <button onClick={() => handleView("6thsem")}>View</button>
                 </span>
               </div>
             </a>
           </div>
 
-          <div class="ag-courses_item">
-            <a href="#" class="ag-courses-item_link">
-              <div class="ag-courses-item_bg"></div>
+          <div className="ag-courses_item">
+            <a href="#" className="ag-courses-item_link">
+              <div className="ag-courses-item_bg"></div>
 
-              <div class="ag-courses-item_title">Semester 7th</div>
+              <div className="ag-courses-item_title">Semester 7th</div>
 
-              <div class="ag-courses-item_date-box">
-                <span class="ag-courses-item_date">
-                  <button onClick={() => handleDownload("4thyrsyllabus")}>
-                    Download
-                  </button>
+              <div className="ag-courses-item_date-box">
+                <span className="ag-courses-item_date">
+                  <button onClick={() => handleDownload("4thyrsyllabus")}>Download</button>
+                  <button onClick={() => handleView("4thyrsyllabus")}>View</button>
                 </span>
               </div>
             </a>
           </div>
 
-          <div class="ag-courses_item">
-            <a href="#" class="ag-courses-item_link">
-              <div class="ag-courses-item_bg"></div>
+          <div className="ag-courses_item">
+            <a href="#" className="ag-courses-item_link">
+              <div className="ag-courses-item_bg"></div>
 
-              <div class="ag-courses-item_title">Semester 8th</div>
+              <div className="ag-courses-item_title">Semester 8th</div>
 
-              <div class="ag-courses-item_date-box">
-                <span class="ag-courses-item_date">
-                  <button onClick={() => handleDownload("4thyrsyllabus")}>
-                    Download
-                  </button>
+              <div className="ag-courses-item_date-box">
+                <span className="ag-courses-item_date">
+                  <button onClick={() => handleDownload("4thyrsyllabus")}>Download</button>
+                  <button onClick={() => handleView("4thyrsyllabus")}>View</button>
                 </span>
               </div>
             </a>

--- a/src/components/page5(1st)/fstsyllabus.js
+++ b/src/components/page5(1st)/fstsyllabus.js
@@ -6,8 +6,6 @@ import {Link} from 'react-router-dom';
 import MyChatbot from "../ChatBot/chatbot";
 
 const fstsyllabus = () => {
-  // const [selectSem, setSelectSem] = useState(null);
-
   const handleDownload = (syllabus) => {
     const syllabusFilePath =
       process.env.PUBLIC_URL + `/syllabus/${syllabus}.pdf`;
@@ -20,28 +18,34 @@ const fstsyllabus = () => {
     document.body.removeChild(link);
   };
 
+  const handleView = (syllabus) => {
+    const syllabusFilePath =
+      process.env.PUBLIC_URL + `/syllabus/${syllabus}.pdf`;
+    window.open(syllabusFilePath, "_blank");
+  };
+
   return (
     <div>
-    <Link to="/fstyear" className="back-icon" style={{ position: 'absolute', top: '75px !important', left: '35px', fontSize: '42px' }}>
-          <svg 
-            xmlns="http://www.w3.org/2000/svg" 
-            width="42" 
-            height="42" 
-            fill="currentColor" 
-            viewBox="0 0 16 16" 
-            style={{ 
-              fontWeight: 'bold',
-              position: 'fixed', 
-              top: 130, 
-              left: 20
-            }}
-          >
-            <path 
-              fillRule="evenodd" 
-              d="M1 8a7 7 0 1 0 14 0A7 7 0 0 0 1 8m15 0A8 8 0 1 1 0 8a8 8 0 0 1 16 0m-4.5-.5a.5.5 0 0 1 0 1H5.707l2.147 2.146a.5.5 0 0 1-.708.708l-3-3a.5.5 0 0 1 0-.708l3-3a.5.5 0 1 1 .708.708L5.707 7.5z"
-            />
-          </svg>
-        </Link>
+      <Link to="/fstyear" className="back-icon" style={{ position: 'absolute', top: '75px !important', left: '35px', fontSize: '42px' }}>
+        <svg 
+          xmlns="http://www.w3.org/2000/svg" 
+          width="42" 
+          height="42" 
+          fill="currentColor" 
+          viewBox="0 0 16 16" 
+          style={{ 
+            fontWeight: 'bold',
+            position: 'fixed', 
+            top: 130, 
+            left: 20
+          }}
+        >
+          <path 
+            fillRule="evenodd" 
+            d="M1 8a7 7 0 1 0 14 0A7 7 0 0 0 1 8m15 0A8 8 0 1 1 0 8a8 8 0 0 1 16 0m-4.5-.5a.5.5 0 0 1 0 1H5.707l2.147 2.146a.5.5 0 0 1-.708.708l-3-3a.5.5 0 0 1 0-.708l3-3a.5.5 0 1 1 .708.708L5.707 7.5z"
+          />
+        </svg>
+      </Link>
       <Header />
       <h2 className="head">Download Syllabus</h2>
 
@@ -55,6 +59,9 @@ const fstsyllabus = () => {
                 <span className="ag-courses-item_date">
                   <button onClick={() => handleDownload("1stsem")}>
                     Download
+                  </button>
+                  <button onClick={() => handleView("1stsem")}>
+                    View
                   </button>
                 </span>
               </div>
@@ -78,13 +85,17 @@ const fstsyllabus = () => {
                   <button onClick={() => handleDownload("2ndsem")}>
                     Download
                   </button>
+                  <button onClick={() => handleView("2ndsem")}>
+                    View
+                  </button>
                 </span>
               </div>
             </a>
           </div>
         </div>
       </div>
-      <Footer /> <MyChatbot />
+      <Footer />
+      <MyChatbot />
     </div>
   );
 };

--- a/src/components/page6(2nd)/sndsyllabus.js
+++ b/src/components/page6(2nd)/sndsyllabus.js
@@ -1,102 +1,86 @@
-import React  from 'react'
+import React from 'react'
 import Header from "../../pages/header";
 import Footer from "../../pages/footer";
 import '../page4/syllabus.css';
-import {Link} from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import MyChatbot from '../ChatBot/chatbot';
 
+const Syllabus = () => {
+  const handleDownload = (syllabus) => {
+    const syllabusFilePath = process.env.PUBLIC_URL + `/syllabus/${syllabus}.pdf`;
 
-const Syllabus =() => {
+    const link = document.createElement('a');
+    link.href = syllabusFilePath;
+    link.download = `syllabus${syllabus}.pdf`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
 
-    // const[selectSem, setSelectSem] = useState(null);
+  const handleView = (syllabus) => {
+    const syllabusFilePath = process.env.PUBLIC_URL + `/syllabus/${syllabus}.pdf`;
+    window.open(syllabusFilePath, "_blank");
+  };
 
-    const handleDownload = (syllabus) =>{
-         const syllabusFilePath =  process.env.PUBLIC_URL +  `/syllabus/${syllabus}.pdf`;
-
-         const link = document.createElement('a');
-         link.href = syllabusFilePath;
-         link.download = `syllabus${syllabus}.pdf`;
-         document.body.appendChild(link);
-         link.click();
-         document.body.removeChild(link);
-    }
   return (
     <div>
-        <Link to="/sndyear" className="back-icon" style={{ position: 'absolute', top: '75px !important', left: '35px', fontSize: '42px' }}>
-          <svg 
-            xmlns="http://www.w3.org/2000/svg" 
-            width="42" 
-            height="42" 
-            fill="currentColor" 
-            viewBox="0 0 16 16" 
-            style={{ 
-              fontWeight: 'bold',
-              position: 'fixed',
-              top: 139, 
-              left: 20
-            }}
-          >
-            <path 
-              fillRule="evenodd" 
-              d="M1 8a7 7 0 1 0 14 0A7 7 0 0 0 1 8m15 0A8 8 0 1 1 0 8a8 8 0 0 1 16 0m-4.5-.5a.5.5 0 0 1 0 1H5.707l2.147 2.146a.5.5 0 0 1-.708.708l-3-3a.5.5 0 0 1 0-.708l3-3a.5.5 0 1 1 .708.708L5.707 7.5z"
-            />
-          </svg>
-        </Link>
-        <Header/>
+      <Link to="/sndyear" className="back-icon" style={{ position: 'absolute', top: '75px !important', left: '35px', fontSize: '42px' }}>
+        <svg 
+          xmlns="http://www.w3.org/2000/svg" 
+          width="42" 
+          height="42" 
+          fill="currentColor" 
+          viewBox="0 0 16 16" 
+          style={{ 
+            fontWeight: 'bold',
+            position: 'fixed',
+            top: 139, 
+            left: 20
+          }}
+        >
+          <path 
+            fillRule="evenodd" 
+            d="M1 8a7 7 0 1 0 14 0A7 7 0 0 0 1 8m15 0A8 8 0 1 1 0 8a8 8 0 0 1 16 0m-4.5-.5a.5.5 0 0 1 0 1H5.707l2.147 2.146a.5.5 0 0 1-.708.708l-3-3a.5.5 0 0 1 0-.708l3-3a.5.5 0 1 1 .708.708L5.707 7.5z"
+          />
+        </svg>
+      </Link>
+      <Header />
 
+      <h2 className='head'>Download Syllabus</h2>
 
-         <h2 className='head'> Download Syllabus</h2>
-         
-         <div class="ag-format-container">
-  <div class="ag-courses_box">
-    
+      <div className="ag-format-container">
+        <div className="ag-courses_box">
+          <div className="ag-courses_item">
+            <a href="#" className="ag-courses-item_link">
+              <div className="ag-courses-item_bg"></div>
+              <div className="ag-courses-item_title">Semester 3rd</div>
+              <div className="ag-courses-item_date-box">
+                <span className="ag-courses-item_date">
+                  <button onClick={() => handleDownload("3rdsem")}>Download</button>
+                  <button onClick={() => handleView("3rdsem")}>View</button>
+                </span>
+              </div>
+            </a>
+          </div>
 
-    
-
-    <div class="ag-courses_item">
-      <a href="#" class="ag-courses-item_link">
-        <div class="ag-courses-item_bg"></div>
-
-        <div class="ag-courses-item_title">
-       Semester 3rd
+          <div className="ag-courses_item">
+            <a href="#" className="ag-courses-item_link">
+              <div className="ag-courses-item_bg"></div>
+              <div className="ag-courses-item_title">Semester 4th</div>
+              <div className="ag-courses-item_date-box">
+                <span className="ag-courses-item_date">
+                  <button onClick={() => handleDownload("4thsem")}>Download</button>
+                  <button onClick={() => handleView("4thsem")}>View</button>
+                </span>
+              </div>
+            </a>
+          </div>
         </div>
-
-        <div class="ag-courses-item_date-box">
-          <span class="ag-courses-item_date">
-          <button onClick={() => handleDownload("3rdsem")} >Download</button>
-
-          </span>
-        </div>
-      </a>
+      </div>
+      <Footer />
+      <MyChatbot />
     </div>
+  );
+};
 
-    <div class="ag-courses_item">
-      <a href="#" class="ag-courses-item_link">
-        <div class="ag-courses-item_bg"></div>
-
-        <div class="ag-courses-item_title">
-          Semester 4th
-        </div>
-
-        <div class="ag-courses-item_date-box">
-          
-          <span class="ag-courses-item_date">
-          <button onClick={() => handleDownload("4thsem")} >Download</button>
-          </span>
-        </div>
-      </a>
-    </div>
-
-
-    
-
-  </div>
-</div>
-      <Footer/> <MyChatbot />
-    </div>
-  )
-}
-
-export default Syllabus
-
-
+export default Syllabus;

--- a/src/components/page7(4yr)/frthsyllabus.js
+++ b/src/components/page7(4yr)/frthsyllabus.js
@@ -1,24 +1,27 @@
-import React  from 'react'
+import React from 'react';
 import Header from "../../pages/header";
 import Footer from "../../pages/footer";
 import '../page4/syllabus.css';
-import {Link} from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import MyChatbot from '../ChatBot/chatbot';
 
-const frthsyllabus =() => {
+const frthsyllabus = () => {
+  const handleDownload = (syllabus) => {
+    const syllabusFilePath = process.env.PUBLIC_URL + `/syllabus/${syllabus}.pdf`;
 
-    // const[selectSem, setSelectSem] = useState(null);
+    const link = document.createElement('a');
+    link.href = syllabusFilePath;
+    link.download = `syllabus${syllabus}.pdf`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
 
-    const handleDownload = (syllabus) =>{
-         const syllabusFilePath =  process.env.PUBLIC_URL +  `/syllabus/${syllabus}.pdf`;
+  const handleView = (syllabus) => {
+    const syllabusFilePath = process.env.PUBLIC_URL + `/syllabus/${syllabus}.pdf`;
+    window.open(syllabusFilePath, "_blank");
+  };
 
-         const link = document.createElement('a');
-         link.href = syllabusFilePath;
-         link.download = `syllabus${syllabus}.pdf`;
-         document.body.appendChild(link);
-         link.click();
-         document.body.removeChild(link);
-    }
   return (
     <div>
       <Link to="/fothyear" className="back-icon" style={{ position: 'absolute', top: '75px !important', left: '35px', fontSize: '42px' }}>
@@ -41,62 +44,43 @@ const frthsyllabus =() => {
           />
         </svg>
       </Link>
-        <Header/>
+      <Header />
 
+      <h2 className='head'>Download Syllabus</h2>
 
-         <h2 className='head'> Download Syllabus</h2>
-         
-         <div class="ag-format-container">
-  <div class="ag-courses_box">
-    
+      <div className="ag-format-container">
+        <div className="ag-courses_box">
+          <div className="ag-courses_item">
+            <a href="#" className="ag-courses-item_link">
+              <div className="ag-courses-item_bg"></div>
+              <div className="ag-courses-item_title">Semester 7th</div>
+              <div className="ag-courses-item_date-box">
+                <span className="ag-courses-item_date">
+                  <button onClick={() => handleDownload("7thsem")}>Download</button>
+                  <button onClick={() => handleView("7thsem")}>View</button>
+                </span>
+              </div>
+            </a>
+          </div>
 
-    <div class="ag-courses_item">
-      <a href="#" class="ag-courses-item_link">
-        <div class="ag-courses-item_bg"></div>
-
-        <div class="ag-courses-item_title">
-         Semester 7th
+          <div className="ag-courses_item">
+            <a href="#" className="ag-courses-item_link">
+              <div className="ag-courses-item_bg"></div>
+              <div className="ag-courses-item_title">Semester 8th</div>
+              <div className="ag-courses-item_date-box">
+                <span className="ag-courses-item_date">
+                  <button onClick={() => handleDownload("8thsem")}>Download</button>
+                  <button onClick={() => handleView("8thsem")}>View</button>
+                </span>
+              </div>
+            </a>
+          </div>
         </div>
-
-        <div class="ag-courses-item_date-box">
-          
-          <span class="ag-courses-item_date">
-          <button onClick={() => handleDownload("4thyrsyllabus")} >Download</button>
-
-          </span>
-        </div>
-      </a>
+      </div>
+      <Footer />
+      <MyChatbot />
     </div>
-
-    <div class="ag-courses_item">
-      <a href="#" class="ag-courses-item_link">
-        <div class="ag-courses-item_bg"></div>
-
-        <div class="ag-courses-item_title">
-         Semester 8th
-        </div>
-
-        <div class="ag-courses-item_date-box">
-          
-          <span class="ag-courses-item_date">
-          <button onClick={() => handleDownload("4thyrsyllabus")} >Download</button>
-
-          </span>
-        </div>
-      </a>
-    </div> 
-    
-   
-
-    
-
-  </div>
-</div>
-      <Footer/> <MyChatbot />
-    </div>
-  )
+  );
 }
 
-export default frthsyllabus
-
-
+export default frthsyllabus;

--- a/src/components/page8(3yr)/trdsyllabus.js
+++ b/src/components/page8(3yr)/trdsyllabus.js
@@ -1,25 +1,27 @@
-import React  from 'react'
+import React from 'react';
 import Header from "../../pages/header";
 import Footer from "../../pages/footer";
 import '../page4/syllabus.css';
-import {Link} from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import MyChatbot from '../ChatBot/chatbot';
 
+const trdsyllabus = () => {
+  const handleDownload = (syllabus) => {
+    const syllabusFilePath = process.env.PUBLIC_URL + `/syllabus/${syllabus}.pdf`;
 
-const trdsyllabus =() => {
+    const link = document.createElement('a');
+    link.href = syllabusFilePath;
+    link.download = `syllabus${syllabus}.pdf`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
 
-    // const[selectSem, setSelectSem] = useState(null);
+  const handleView = (syllabus) => {
+    const syllabusFilePath = process.env.PUBLIC_URL + `/syllabus/${syllabus}.pdf`;
+    window.open(syllabusFilePath, "_blank");
+  };
 
-    const handleDownload = (syllabus) =>{
-         const syllabusFilePath =  process.env.PUBLIC_URL +  `/syllabus/${syllabus}.pdf`;
-
-         const link = document.createElement('a');
-         link.href = syllabusFilePath;
-         link.download = `syllabus${syllabus}.pdf`;
-         document.body.appendChild(link);
-         link.click();
-         document.body.removeChild(link);
-    }
   return (
     <div>
       <Link to="/trdyear" className="back-icon" style={{ position: 'absolute', top: '75px !important', left: '35px', fontSize: '42px' }}>
@@ -42,62 +44,43 @@ const trdsyllabus =() => {
           />
         </svg>
       </Link>
-        <Header/>
+      <Header />
 
+      <h2 className='head'>Download Syllabus</h2>
 
-         <h2 className='head'> Download Syllabus</h2>
-         
-         <div class="ag-format-container">
-  <div class="ag-courses_box">
-    
+      <div className="ag-format-container">
+        <div className="ag-courses_box">
+          <div className="ag-courses_item">
+            <a href="#" className="ag-courses-item_link">
+              <div className="ag-courses-item_bg"></div>
+              <div className="ag-courses-item_title">Semester 5th</div>
+              <div className="ag-courses-item_date-box">
+                <span className="ag-courses-item_date">
+                  <button onClick={() => handleDownload("5thsem")}>Download</button>
+                  <button onClick={() => handleView("5thsem")}>View</button>
+                </span>
+              </div>
+            </a>
+          </div>
 
-    
-
-   
-
-    
-    <div class="ag-courses_item">
-      <a href="#" class="ag-courses-item_link">
-        <div class="ag-courses-item_bg"></div>
-
-        <div class="ag-courses-item_title">
-         Semester 5th
+          <div className="ag-courses_item">
+            <a href="#" className="ag-courses-item_link">
+              <div className="ag-courses-item_bg"></div>
+              <div className="ag-courses-item_title">Semester 6th</div>
+              <div className="ag-courses-item_date-box">
+                <span className="ag-courses-item_date">
+                  <button onClick={() => handleDownload("6thsem")}>Download</button>
+                  <button onClick={() => handleView("6thsem")}>View</button>
+                </span>
+              </div>
+            </a>
+          </div>
         </div>
-
-        <div class="ag-courses-item_date-box">
-          
-          <span class="ag-courses-item_date">
-          <button onClick={() => handleDownload("5thsem")} >Download</button>
-
-          </span>
-        </div>
-      </a>
+      </div>
+      <Footer />
+      <MyChatbot />
     </div>
+  );
+};
 
-    <div class="ag-courses_item">
-      <a href="#" class="ag-courses-item_link">
-        <div class="ag-courses-item_bg"></div>
-
-        <div class="ag-courses-item_title">
-         Semester 6th
-        </div>
-
-        <div class="ag-courses-item_date-box">
-          
-          <span class="ag-courses-item_date">
-          <button onClick={() => handleDownload("6thsem")} >Download</button>
-
-          </span>
-        </div>
-      </a>
-    </div>
-  </div>
-</div>
-      <Footer/> <MyChatbot />
-    </div>
-  )
-}
-
-export default trdsyllabus
-
-
+export default trdsyllabus;


### PR DESCRIPTION
Fixing issue #281 

- Added a "View" button next to the "Download" button in the syllabus components for each year.
- The "View" button allows users to open the syllabus PDF in a new tab, providing an option to preview the syllabus without downloading it.
- Updated the first year (`fstsyllabus`), second year (`sndsyllabus`), third year (`trdsyllabus`), and fourth year (`frthsyllabus`) components to include the "View" functionality.
- Adjusted CSS to ensure the buttons are displayed properly next to each other.
- Improved user experience by providing quick access to syllabus previews.
- Screenshot
![Screenshot 2024-07-13 114122](https://github.com/user-attachments/assets/25514062-5fe3-496b-9dfd-37889e736ac8)
